### PR TITLE
Fiks MacOS ARM64 installasjons instrukser i docs/installation.md

### DIFF
--- a/.github/workflows/analyze-test-lint.yml
+++ b/.github/workflows/analyze-test-lint.yml
@@ -31,7 +31,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: elvia-runner
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ Therefore it's useful to use `3lv` when debugging or testing Elvia's actions, si
 
 ## 💥 Breaking changes
 
-Before version `v1.0.0` is released, breaking changes will happen in minor versions (and possibly also patch versions). 
+Before version `v1.0.0` is released, breaking changes will happen in minor versions (and possibly also patch versions).

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ Therefore it's useful to use `3lv` when debugging or testing Elvia's actions, si
 
 ## 💥 Breaking changes
 
-Before version `v1.0.0` is released, breaking changes will happen in minor versions (and possibly also patch versions).
+Before version `v1.0.0` is released, breaking changes will happen in minor versions (and possibly also patch versions). 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,7 +18,7 @@ extract it and move the binary to a directory in your PATH.
 
 If you are using WSL, you can install the Linux binary.
 
-#### Example installation
+#### Example Linux installation
 
 ```bash
 # OPTIONAL: verify checksum first
@@ -28,7 +28,13 @@ tar -xzf 3lv-linux-amd64.tar.gz
 sudo install -Dm755 -t /usr/local/bin 3lv
 ```
 
-For macOS, you can use the same commands as above, but replace `linux` with `macos`.
+#### Example Mac installation
+The installation is done by first installing the app, secondly trying (and failing) to open it, and thirdly [allowing the opening of it](https://support.apple.com/en-gb/guide/mac-help/mh40616/mac).
+```bash
+tar -xzf 3lv-macos-arm64.tar.gz
+sudo install -Dm755 3lv /usr/local/bin/
+```
+
 **If you have an M1 or newer mac, you can use the `macos-arm64` binary.**
 
 ### Windows


### PR DESCRIPTION
`-t` for target var ikke støttet, og da kom parameterne feil vei i tillegg.
Måtte tillate åpning også, så greit å lenke direkte til kilden for å fikse det og.