### PR TITLE
Fix CVE-2024-12797 and use alpine:latest for Go

### DIFF
--- a/pkg/build/Dockerfile.dotnet.tmpl
+++ b/pkg/build/Dockerfile.dotnet.tmpl
@@ -25,6 +25,9 @@ RUN apk update && \
     apk add --no-cache \
         icu-libs
 
+# CVE-2024-12797
+RUN apk add --no-cache libssl3 libcrypto3
+
 WORKDIR /app
 
 COPY --from=build /app/out .

--- a/pkg/build/Dockerfile.go.tmpl
+++ b/pkg/build/Dockerfile.go.tmpl
@@ -12,11 +12,14 @@ COPY . .
 RUN go build -o ./out/executable {{ .MainPackageDirectory }}
 
 
-FROM alpine:3.21
+FROM alpine:latest
 LABEL maintainer="elvia@elvia.no"
 
 RUN apk update && \
     apk upgrade --no-cache
+
+# CVE-2024-12797
+RUN apk add --no-cache libssl3 libcrypto3
 
 RUN addgroup application-group --gid 1001 && \
     adduser application-user --uid 1001 \

--- a/pkg/build/_test/Dockerfile.dotnet.test
+++ b/pkg/build/_test/Dockerfile.dotnet.test
@@ -1,0 +1,40 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
+LABEL maintainer="elvia@elvia.no"
+
+WORKDIR /app
+COPY . .
+
+RUN dotnet tool restore && \
+    dotnet restore dotnet-8.0.csproj && \
+    dotnet publish \
+      dotnet-8.0.csproj \
+      --configuration Release \
+      --output ./out
+
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS runtime
+LABEL maintainer="elvia@elvia.no"
+
+RUN addgroup application-group --gid 1001 && \
+    adduser application-user --uid 1001 \
+        --ingroup application-group \
+        --disabled-password
+
+RUN apk update && \
+    apk upgrade --no-cache && \
+    apk add --no-cache \
+        icu-libs
+
+# CVE-2024-12797
+RUN apk add --no-cache libssl3 libcrypto3
+
+WORKDIR /app
+
+COPY --from=build /app/out .
+
+RUN chown --recursive application-user .
+USER application-user
+
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "SelfDefinedAssemblyName.dll"]

--- a/pkg/build/_test/Dockerfile.go.test
+++ b/pkg/build/_test/Dockerfile.go.test
@@ -12,11 +12,14 @@ COPY . .
 RUN go build -o ./out/executable ./cmd/demo-api-go
 
 
-FROM alpine:3.21
+FROM alpine:latest
 LABEL maintainer="elvia@elvia.no"
 
 RUN apk update && \
     apk upgrade --no-cache
+
+# CVE-2024-12797
+RUN apk add --no-cache libssl3 libcrypto3
 
 RUN addgroup application-group --gid 1001 && \
     adduser application-user --uid 1001 \

--- a/pkg/build/generate_test.go
+++ b/pkg/build/generate_test.go
@@ -259,6 +259,41 @@ func TestFindBaseImageTag3(t *testing.T) {
 	}
 }
 
+func TestGenerateDotnetDockerfile(t *testing.T) {
+	t.Parallel()
+
+	expectedDockerfile, err := os.ReadFile("_test/Dockerfile.dotnet.test")
+	if err != nil {
+		t.Errorf("Error reading file: %v", err)
+	}
+
+	const (
+		projectFile          = "_test/dotnet-8.0.csproj"
+		expectedBuildContext = "_test"
+	)
+
+	actualDockerfilePath, actualBuildContext, err := generateDockerfile(
+		projectFile,
+		GenerateDockerfileOptions{},
+	)
+	if err != nil {
+		t.Errorf("Error generating Dockerfile: %v", err)
+	}
+
+	actualDockerfile, err := os.ReadFile(actualDockerfilePath)
+	if err != nil {
+		t.Errorf("Error reading file: %v", err)
+	}
+
+	if string(expectedDockerfile) != string(actualDockerfile) {
+		t.Errorf("Dockerfile mismatch: expected %s, got %s", expectedDockerfile, actualDockerfile)
+	}
+
+	if expectedBuildContext != actualBuildContext {
+		t.Errorf("Build context mismatch: expected %s, got %s", expectedBuildContext, actualBuildContext)
+	}
+}
+
 func TestGenerateGoDockerfile(t *testing.T) {
 	t.Parallel()
 
@@ -267,9 +302,10 @@ func TestGenerateGoDockerfile(t *testing.T) {
 		t.Errorf("Error reading file: %v", err)
 	}
 
-	expectedBuildContext := "."
-
-	const projectFile = "go.mod"
+	const (
+		projectFile          = "go.mod"
+		expectedBuildContext = "."
+	)
 
 	actualDockerfilePath, actualBuildContext, err := generateDockerfile(
 		projectFile,
@@ -303,11 +339,10 @@ func TestGeneratePythonDockerfile1(t *testing.T) {
 		t.Errorf("Error reading file: %v", err)
 	}
 
-	expectedBuildContext := "."
-
 	const (
-		projectFile     = "pyproject.toml"
-		applicationName = "demo-api-python"
+		projectFile          = "pyproject.toml"
+		expectedBuildContext = "."
+		applicationName      = "demo-api-python"
 	)
 
 	actualDockerfilePath, actualBuildContext, err := generateDockerfile(


### PR DESCRIPTION
https://elvia.grafana.net/d/fdu6tvs5tpszkc/trivy-image-vulnerabilities?orgId=1&from=now-6h&to=now&timezone=browser&var-namespace=core&var-severity=$__all&var-environment=$__all